### PR TITLE
replaced start with explorer.exe and tested on win32 and linux.

### DIFF
--- a/openurl.js
+++ b/openurl.js
@@ -1,20 +1,20 @@
-var format = require("util").format;
-var exec = require('child_process').exec;
+var format = require('util').format,
+    spawn = require('child_process').spawn;
 
 var command;
 
-switch (process.platform) {
-    case "darwin":
-        command = "open '%s'";
-        break;
-    case "win32":
-        command = "start '%s'";
-        break;
-    case "linux2":
-        command = "xdg-open '%s'";
-        break;
-    default:
-        throw new Error("Unsupported platform: "+process.platform);
+switch(process.platform) {
+  case 'darwin':
+    command = 'open';
+    break;
+  case 'win32':
+    command = 'explorer.exe';
+    break;
+  case 'linux':
+    command = 'xdg-open';
+    break;
+  default:
+    throw new Error('Unsupported platform: ' + process.platform);
 }
 
 /**
@@ -23,12 +23,14 @@ switch (process.platform) {
  * @param url The URL to open
  * @param callback A 0-argument function called after everything finishes successfully
  */
-exports.open = function (url, callback) {
-    exec(format(command, url), function (error, stdout, stderr) {
-        if (error) {
-            throw error;
-        } else {
-            callback();
-        }
-    });
+
+exports.open = function(url, callback) {
+  spawn(command, [url], function(error, stdout, stderr) {
+    if (error) {
+      throw error;
+    }
+    else {
+      callback();
+    }
+  });
 }


### PR DESCRIPTION
replaced exec with spawn
replaced 'start' with 'explorer.exe' on win32 (tested on Win7 32-bit)
replaced 'linux2' with 'linux' (tested on Linux Mint 32-bit)
