### PR TITLE
android support added

### DIFF
--- a/openurl.js
+++ b/openurl.js
@@ -12,6 +12,9 @@ switch(process.platform) {
     case 'linux':
         command = 'xdg-open';
         break;
+    case 'android':
+        command = 'xdg-open';
+        break;
     default:
         throw new Error('Unsupported platform: ' + process.platform);
 }


### PR DESCRIPTION
Packages that rely on openurl and run within [termux](https://github.com/termux) are unsupported. For example Localtunnel. Actually termux has it's own xdg-open, so it's totally okay to handle `process.platform === 'android'`.