### PR TITLE
Added promises / add options for error handling

### DIFF
--- a/openurl.js
+++ b/openurl.js
@@ -24,6 +24,18 @@ switch(process.platform) {
  */
 
 function open(url, callback) {
+    if(callback == null) {
+        return new Promise((resolve, reject) => {
+            open(url, (error) => {
+                if(error) {
+                    reject(error);
+                }
+                else {
+                    resolve();
+                }
+            })
+        });
+    }
     var child = spawn(command, [url]);
     var errorText = "";
     child.stderr.setEncoding('utf8');
@@ -38,8 +50,9 @@ function open(url, callback) {
             } else {
                 console.error(error.message);
             }
-        } else if (callback) {
-            callback(error);
+        }
+        else if (callback) {
+            callback();
         }
     });
 }
@@ -61,7 +74,7 @@ function mailto(recipients, fields, recipientsSeparator, callback) {
         }
         url += key + "=" + encodeURIComponent(fields[key]);
     });
-    open(url, callback);
+    return open(url, callback);
 }
 
 exports.open = open;

--- a/openurl.js
+++ b/openurl.js
@@ -20,6 +20,7 @@ switch(process.platform) {
  * Error handling is deliberately minimal, as this function is to be easy to use for shell scripting
  *
  * @param url The URL to open
+ * @param options (optional) An object of options to pass. `silent`: don't log errors;
  * @param callback A function with a single error argument. Optional.
  * @returns a Promise if no callback is given
  */

--- a/openurl.js
+++ b/openurl.js
@@ -20,7 +20,7 @@ switch(process.platform) {
  * Error handling is deliberately minimal, as this function is to be easy to use for shell scripting
  *
  * @param url The URL to open
- * @param options (optional) An object of options to pass. `silent`: don't log errors;
+ * @param options (optional) An object of options to pass. silent: don't log errors;
  * @param callback A function with a single error argument. Optional.
  * @returns a Promise if no callback is given
  */

--- a/openurl.js
+++ b/openurl.js
@@ -21,6 +21,7 @@ switch(process.platform) {
  *
  * @param url The URL to open
  * @param callback A function with a single error argument. Optional.
+ * @returns a Promise if no callback is given
  */
 
 function open(url, options, callback) {
@@ -31,7 +32,7 @@ function open(url, options, callback) {
     else {
         options = Object.assign({}, options);
     }
-    if(callback == null) {
+    if(callback === undefined) {
         return new Promise((resolve, reject) => {
             open(url, (error) => {
                 if(error) {

--- a/openurl.js
+++ b/openurl.js
@@ -12,8 +12,6 @@ switch(process.platform) {
     default:
         command = 'xdg-open';
         break;
-    default:
-        throw new Error('Unsupported platform: ' + process.platform);
 }
 
 /**

--- a/openurl.js
+++ b/openurl.js
@@ -85,7 +85,7 @@ function open(url, options, callback) {
         if(endedStderr) {
             finish();
         }
-    }
+    });
 }
 
 /**

--- a/openurl.js
+++ b/openurl.js
@@ -23,7 +23,14 @@ switch(process.platform) {
  * @param callback A function with a single error argument. Optional.
  */
 
-function open(url, callback) {
+function open(url, options, callback) {
+    if(typeof options === 'function') {
+        callback = options;
+        options = {};
+    }
+    else {
+        options = Object.assign({}, options);
+    }
     if(callback == null) {
         return new Promise((resolve, reject) => {
             open(url, (error) => {
@@ -48,7 +55,9 @@ function open(url, callback) {
             if (callback) {
                 callback(error);
             } else {
-                console.error(error.message);
+                if(!options.silent) {
+                    console.error(error.message);
+                }
             }
         }
         else if (callback) {

--- a/openurl.js
+++ b/openurl.js
@@ -7,9 +7,9 @@ switch(process.platform) {
         command = 'open';
         break;
     case 'win32':
-        command = 'explorer.exe';
+        command = 'start';
         break;
-    case 'linux':
+    default:
         command = 'xdg-open';
         break;
     default:
@@ -61,14 +61,12 @@ function open(url, options, callback) {
             var error = new Error(errorText);
             if (callback) {
                 callback(error);
-            }
-            else {
+            } else {
                 if(!options.silent) {
                     console.error(error.message);
                 }
             }
-        }
-        else if (callback) {
+        } else if (callback) {
             callback();
         }
     }

--- a/openurl.js
+++ b/openurl.js
@@ -36,7 +36,7 @@ function open(url, callback) {
             if (callback) {
                 callback(error);
             } else {
-                throw error;
+                console.error(error.message);
             }
         } else if (callback) {
             callback(error);

--- a/openurl.js
+++ b/openurl.js
@@ -71,7 +71,7 @@ function open(url, options, callback) {
  *     Some email apps let you specify arbitrary headers here.
  * @param recipientsSeparator Default is ",". Use ";" for Outlook.
  */
-function mailto(recipients, fields, recipientsSeparator, callback) {
+function mailto(recipients, fields, recipientsSeparator, ...openargs) {
     recipientsSeparator = recipientsSeparator || ",";
 
     var url = "mailto:"+recipients.join(recipientsSeparator);
@@ -83,7 +83,7 @@ function mailto(recipients, fields, recipientsSeparator, callback) {
         }
         url += key + "=" + encodeURIComponent(fields[key]);
     });
-    return open(url, callback);
+    return open(url, ...openargs);
 }
 
 exports.open = open;


### PR DESCRIPTION
I made it so that if a callback isn't passed, a promise will be returned.

I also fixed your handling of the error in the `end` event. It's usually better to handle errors rather than throwing them. The `options` argument lets you silence error logging.
