### PR TITLE
Add WSL detection for linux hosts

### DIFF
--- a/openurl.js
+++ b/openurl.js
@@ -2,6 +2,17 @@ var spawn = require('child_process').spawn;
 
 var command;
 
+function isWSL() {
+    const fs = require('fs');
+    try {
+        const contents = fs.readFileSync('/proc/version', 'utf-8');
+        return Boolean(contents.match(/.*microsoft|wsl.*/i));
+    } catch (err) {
+        /* swallow */
+        return false;
+    }
+}
+
 switch(process.platform) {
     case 'darwin':
         command = 'open';
@@ -10,7 +21,7 @@ switch(process.platform) {
         command = 'explorer.exe';
         break;
     case 'linux':
-        command = 'xdg-open';
+        command = isWSL() ? 'explorer.exe' : 'xdg-open';
         break;
     default:
         throw new Error('Unsupported platform: ' + process.platform);


### PR DESCRIPTION
On linux systems running in WSL, xdg doesn't exist. Instead, `explorer.exe` is patched through and works as it would on Windows. This is a backwards-compatible check to add support for WSL cases.