### PR TITLE
feat: add minimalist TypeScript type definition file

### DIFF
--- a/openurl.d.ts
+++ b/openurl.d.ts
@@ -1,0 +1,11 @@
+export declare function open(
+  url: string,
+  callback?: (error: Error) => void
+): void;
+
+export declare function mailto(
+  recipients: string[],
+  fields: Record<string, string>,
+  recipientsSeparator: string,
+  callback?: (error: Error) => void
+): void;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Axel Rauschmayer <axe@rauschma.de>",
   "description": "Open a URL via the operating system (http: in default browser, mailto: in mail client etc.",
   "main": "./openurl.js",
+  "types": "openurl.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/rauschma/openurl"


### PR DESCRIPTION
Hello @rauschma,

Here is a quick proposal to add a basic TypeScript type definition file `openurl.d.ts`, avoiding TypeScript libraries such as [skott](https://github.com/antoine-coulon/skott) to do module augmentation.

Thanks