### PR TITLE
added support for android.

### DIFF
--- a/openurl.js
+++ b/openurl.js
@@ -9,6 +9,8 @@ switch(process.platform) {
     case 'win32':
         command = 'explorer.exe';
         break;
+    case 'android':
+        command = 'termux-open-url';
     case 'linux':
         command = 'xdg-open';
         break;


### PR DESCRIPTION
Recently I've been trying to run npm local tunnel package (https://github.com/localtunnel/localtunnel) from my termux app within android.

But openurl doesn't have a way to open the url in android. So it crashes the package.
Added a few lines to quick fix the problem.

TODO: Additional checks such as environment variables can be added to fix this issue for every other platform.